### PR TITLE
fix string compare err

### DIFF
--- a/src/Parser/Excel2007.php
+++ b/src/Parser/Excel2007.php
@@ -218,7 +218,13 @@ class Excel2007 {
                                     $nonEmpty = false;
                                 }
 
-                                if ($columnLetter > $info['lastColumnLetter']) {
+                                $columnLetterLen  = strlen($columnLetter);
+                                $lastColumnLetterLen = strlen($info['lastColumnLetter']);
+                                if ($columnLetterLen == $lastColumnLetterLen) {
+                                    if ($columnLetter > $info['lastColumnLetter']) {
+                                        $info['lastColumnLetter'] = $columnLetter;
+                                    }
+                                } else if ($columnLetterLen > $lastColumnLetterLen){
                                     $info['lastColumnLetter'] = $columnLetter;
                                 }
                             }


### PR DESCRIPTION
String compare error when one char string and two chars string.
for example
original code 'W' is greater than 'AI'
but the correct result is 'AI' greater than 'W'